### PR TITLE
feat(almanax): add ecocraft slash command and model

### DIFF
--- a/cogs/almanax.py
+++ b/cogs/almanax.py
@@ -1,0 +1,58 @@
+from nextcord import SlashOption, slash_command
+from nextcord.ext import commands
+from nextcord.interactions import Interaction
+
+from models.almanax.ecocraft import EcoCraft
+
+
+class Almanax(commands.Cog):
+    JOBS = {
+        "Eleveur": "Breeder",
+        "Bûcheron": "Lumberjack",
+        "Chasseur": "Hunter",
+        "Pêcheur": "Fisherman",
+        "Mineur": "Miner",
+        "Paysans": "Farmer",
+        "Bricoleur": "Handyman",
+        "Alchimiste": "Alchemist",
+        "Forgeron": "Smith",
+        "Bijoutier": "Jeweller",
+        "Cordonnier": "Shoemaker",
+        "Tailleur": "Tailor",
+        "Sculpteur": "Carver",
+        "Faconneur": "Artificer",
+    }
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @slash_command(name="ecocraft", description="Affiche le jour de l'écocraft")
+    async def ecocraft(
+        self,
+        interaction: Interaction,
+        metier: str = SlashOption(
+            name="métier",
+            description="Le métier pour lequel vous voulez connaître le jour de l'écocraft",
+            choices=JOBS,
+            required=False,
+        ),
+    ) -> None:
+        """Affiche l'almanax du jour."""
+        if not metier:
+            dates = EcoCraft.get_all_dates()
+            message = "Voici les jours de l'écocraft pour tous les métiers :\n"
+            for bonus, day, month in dates:
+                message += f"**{day}/{month}** : {bonus}\n"
+            _ = await interaction.response.send_message(message, ephemeral=True)
+
+        else:
+            eco_craft = EcoCraft(metier)
+            date = eco_craft.get_date()
+            _ = await interaction.response.send_message(
+                f"Le jour de l'écocraft pour le métier {next((k for k, v in self.JOBS.items() if v == metier))} est le  **{date[0]}/{date[1]}**",
+                ephemeral=True,
+            )
+
+
+def setup(bot):
+    bot.add_cog(Almanax(bot))

--- a/models/almanax/ecocraft.py
+++ b/models/almanax/ecocraft.py
@@ -1,0 +1,32 @@
+import config
+import httpx
+
+
+class EcoCraft:
+    api_url: str = config.BACKEND_URL + "almanax/api/economy-entries/"
+
+    headers: dict[str, str] = {"Authorization": config.BACKEND_TOKEN}
+
+    def __init__(self, job: str):
+        self.job = job
+
+    def get_date(self):
+        res: httpx.Response = httpx.get(
+            self.api_url + "get_job/", params={"job": self.job}, headers=self.headers
+        )
+        data = res.json()
+        return (data.get("day"), data.get("month"))
+
+    @staticmethod
+    def get_all_dates():
+        res: httpx.Response = httpx.get(EcoCraft.api_url, headers=EcoCraft.headers)
+        res_json = res.json()
+        data = []
+        data.extend(res_json.get("results", []))
+        while res_json.get("next"):
+            res = httpx.get(res_json["next"], headers=EcoCraft.headers)
+            res_json = res.json()
+            data.extend(res_json.get("results", []))
+        return [
+            (entry.get("bonus"), entry.get("day"), entry.get("month")) for entry in data
+        ]


### PR DESCRIPTION
Add a new slash command `/ecocraft` in the Almanax cog to display EcoCraft days for professions. Introduce the EcoCraft model to fetch dates from the backend API. Supports querying for all jobs or a specific job, with French-to-English job mapping.